### PR TITLE
wake.js: show type only for the green expressions

### DIFF
--- a/lib/style.js
+++ b/lib/style.js
@@ -28,19 +28,13 @@ pre {
 
 .Program    { color: #999; }
 .VarRef     { color: white; }
-.VarDef     { color: yellow; }
-.VarArg     { color: blue; }
+.VarDef     { color: #ee3; }
+.VarArg     { color: #55f; }
 .Prim       { color: yellow; }
 .Literal    { color: pink; }
 
-.VarRef:hover     { background-color: hsla(0, 100%, 100%, 0.1); }
-.VarDef:hover     { background-color: hsla(0, 100%, 100%, 0.1); }
-.VarArg:hover     { background-color: hsla(0, 100%, 100%, 0.1); }
-.Prim:hover       { background-color: hsla(0, 100%, 100%, 0.1); }
-.Literal:hover    { background-color: hsla(0, 100%, 100%, 0.1); }
-.App:hover        { background-color: hsla(0, 100%, 100%, 0.1); }
-.Lambda:hover     { background-color: hsla(0, 100%, 100%, 0.1); }
-.DefBinding:hover { background-color: hsla(0, 100%, 100%, 0.1); }
+*[sourceType]:hover { background-color: hsla(0, 100%, 100%, 0.1); }
+*[focus='true']:hover { background-color: green; }
 
 @-webkit-keyframes target-fade {
   from { background-color: red; } /* [1] */


### PR DESCRIPTION
Hitting +/- expands or shrinks the green selection of the tooltip.
Clicking on a variable definition now highlights all the uses.
Removed 'id' tags from non-targetable elements.